### PR TITLE
Automate cluster setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If the deployment is scaled *up* after the initial creation those new Pods will
 be automatically added. Scaling *down* does not automatically remove the Pods
 from the membership database at this time.
 
-# Added functionality on top of upstream repo (kocolosk/couchdb-statefulset-assembler)
+### Added functionality on top of upstream repo (kocolosk/couchdb-statefulset-assembler)
 1. Ensure that all CouchDB containers get all peers registered in _node db_
 2. Do the POST http://127.0.0.1:5984/_cluster_setup , payload {"action": "finish_cluster"} on pod with ordinal nr 0 (if username and password provided)
 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,115 @@ cluster is automically joined up.
 If the deployment is scaled *up* after the initial creation those new Pods will
 be automatically added. Scaling *down* does not automatically remove the Pods
 from the membership database at this time.
+
+# Added functionality on top of upstream repo (kocolosk/couchdb-statefulset-assembler)
+1. Ensure that all CouchDB containers get all peers registered in _node db_
+2. Do the POST http://127.0.0.1:5984/_cluster_setup , payload {"action": "finish_cluster"} on pod with ordinal nr 0 (if username and password provided)
+
+The intention is that the cluster will succeed with setup even if some of the CouchDB nodes are restarted during cluster formation (e.g. due to Liveness or Readiness settings).
+
+Below are example logs from formation of a 3-node cluster.
+```
+kubectl logs -f my-release-couchdb-2 -c couchdb-statefulset-assembler       
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+	| Got the following peers' fqdm from DNS lookup: ['my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local']
+Adding CouchDB cluster node my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
+	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local
+	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
+Adding CouchDB cluster node my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
+	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local
+	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
+Adding CouchDB cluster node my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
+	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local
+	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
+Probing my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local for cluster membership
+	| In sync!
+Probing my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local for cluster membership
+	| In sync!
+Probing my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local for cluster membership
+	| In sync!
+Cluster membership populated!
+Intentionally skipping the POST to http://127.0.0.1:5984/_cluster_setup {"action": "finish_cluster"}
+```
+
+```
+kubectl logs -f my-release-couchdb-1 -c couchdb-statefulset-assembler
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+	| Got the following peers' fqdm from DNS lookup: ['my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local']
+Adding CouchDB cluster node my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
+	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local
+	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
+Adding CouchDB cluster node my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
+	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local
+	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
+Adding CouchDB cluster node my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
+	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local
+	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
+Probing my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local for cluster membership
+	| In sync!
+Probing my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local for cluster membership
+	| In sync!
+Probing my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local for cluster membership
+	| In sync!
+Cluster membership populated!
+Intentionally skipping the POST to http://127.0.0.1:5984/_cluster_setup {"action": "finish_cluster"}
+```
+
+```
+kubectl logs -f my-release-couchdb-0 -c couchdb-statefulset-assembler
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+	| Got the following peers' fqdm from DNS lookup: ['my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local']
+Adding CouchDB cluster node my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
+	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local
+	| Response: 201 {'ok': True, 'id': 'couchdb@my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local', 'rev': '1-967a00dff5e02add41819138abb3284d'}
+Adding CouchDB cluster node my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
+	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local
+	| Response: 201 {'ok': True, 'id': 'couchdb@my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local', 'rev': '1-967a00dff5e02add41819138abb3284d'}
+Adding CouchDB cluster node my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
+	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local
+	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
+Probing my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local for cluster membership
+	| Cluster members in my-release-couchdb-0 not yet present in my-release-couchdb-2: {'couchdb@my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local', 'couchdb@my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local'}
+Probing my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local for cluster membership
+	| Cluster members in my-release-couchdb-0 not yet present in my-release-couchdb-1: {'couchdb@my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local', 'couchdb@my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local'}
+Probing my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local for cluster membership
+	| In sync!
+Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
+	| Got the following peers' fqdm from DNS lookup: ['my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local']
+Adding CouchDB cluster node my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
+	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local
+	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
+Adding CouchDB cluster node my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
+	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local
+	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
+Adding CouchDB cluster node my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
+	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local
+	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
+Probing my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local for cluster membership
+	| In sync!
+Probing my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local for cluster membership
+	| In sync!
+Probing my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local for cluster membership
+	| In sync!
+Cluster membership populated!
+Get the cluster up and running
+	| Request: POST http://127.0.0.1:5984/_cluster_setup , payload {"action": "finish_cluster"}
+	|	Response: 201 {'ok': True}
+	| Sweet! Just a final check for the logs...
+	| Request: GET http://127.0.0.1:5984/_cluster_setup
+	|	Response: 200 {'state': 'cluster_finished'}
+Time to relax!
+```

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -98,7 +98,7 @@ def finish_cluster(names):
         print ("=== Adding nodes to CouchDB cluster via the “setup coordination node” ===")
         for name in names:
             # Exclude "this" pod
-            if (name.split(".", 1) != os.getenv("HOSTNAME")):
+            if (name.split(".",1)[0]) != os.getenv("HOSTNAME")):
                 # action: enable_cluster
                 payload = {}
                 payload['action'] = 'enable_cluster'
@@ -194,6 +194,8 @@ def sleep_forever():
 if __name__ == '__main__':
     peer_names = discover_peers(construct_service_record())
     print("Got the following peers' fqdm from DNS lookup:",peer_names,flush=True)
+    if (os.getenv("COUCHDB_USER") and os.getenv("COUCHDB_PASSWORD")):
+        enable_cluster(len(peer_names))
     connect_the_dots(peer_names)
     print('Cluster membership populated!')
     if (os.getenv("COUCHDB_USER") and os.getenv("COUCHDB_PASSWORD")):

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -91,12 +91,11 @@ def finish_cluster(names):
                     remote_resp = requests.get("http://{0}:5984/_members".format(name))
             print("CouchDB cluster member {} ready to form a cluster".format(name))
         # At this point ALL peers have _nodes populated. Finish the cluster setup!
-        payload = {}
         if creds[0] and creds[1]:
             setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={"action": "finish_cluster"},  auth=creds)
         else:
             setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={"action": "finish_cluster"})
-        if setup_resp.status_code == 200:
+        if (setup_resp.status_code == 200):
             print("CouchDB cluster done. Time to relax!")
         else:
             print('Ouch! Failed with final step. http://127.0.0.1:5984/_cluster_setup returned {0}'.format(setup_resp.status_code))

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -160,19 +160,6 @@ def finish_cluster(names):
             print('CouchDB cluster peer {} added to "setup coordination node"'.format(name))
         # At this point ALL peers have _nodes populated. Finish the cluster setup!
 
-"""         print("== Creating default databases ===")
-        setup_resp=requests.put("http://127.0.0.1:5984/_users",  auth=creds)
-        print ("\tRequest: PUT http://127.0.0.1:5984/_users")
-        print ("\t\tResponse:", setup_resp.status_code, setup_resp.json())
-
-        setup_resp=requests.put("http://127.0.0.1:5984/_replicator",  auth=creds)
-        print ("\tRequest: PUT http://127.0.0.1:5984/_replicator")
-        print ("\t\tResponse:", setup_resp.status_code, setup_resp.json())
-
-        setup_resp=requests.put("http://127.0.0.1:5984/_global_changes",  auth=creds)
-        print ("\tRequest: PUT http://127.0.0.1:5984/_global_changes")
-        print ("\t\tResponse:", setup_resp.status_code, setup_resp.json()) """
-
         setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={"action": "finish_cluster"},  auth=creds)
         if (setup_resp.status_code == 201):
             print("== CouchDB cluster setup done! ===")

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -157,28 +157,29 @@ def finish_cluster(names):
                     remote_resp = requests.get(remote_membership_uri,  auth=creds)
             print("Node {0} has all node members in place!".format(name))
 
-
             print('CouchDB cluster peer {} added to "setup coordination node"'.format(name))
         # At this point ALL peers have _nodes populated. Finish the cluster setup!
+
+        print("== Creating default databases ===")
+        setup_resp=requests.put("http://127.0.0.1:5984/_users",  auth=creds)
+        print ("\tRequest: PUT http://127.0.0.1:5984/_users")
+        print ("\t\tResponse:", setup_resp.status_code, setup_resp.json())
+
+        setup_resp=requests.put("http://127.0.0.1:5984/_replicator",  auth=creds)
+        print ("\tRequest: PUT http://127.0.0.1:5984/_replicator")
+        print ("\t\tResponse:", setup_resp.status_code, setup_resp.json())
+
+        setup_resp=requests.put("http://127.0.0.1:5984/_global_changes",  auth=creds)
+        print ("\tRequest: PUT http://127.0.0.1:5984/_global_changes")
+        print ("\t\tResponse:", setup_resp.status_code, setup_resp.json())
+
         setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={"action": "finish_cluster"},  auth=creds)
         if (setup_resp.status_code == 201):
             print("== CouchDB cluster setup done! ===")
-            setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup")
-            print("CouchDB cluster setup done.")
-            print ("\tRequest: GET http://127.0.0.1:5984/_cluster_setup")
+            print ('\tRequest: POST http://127.0.0.1:5984/_cluster_setup , payload {"action": "finish_cluster"}')
             print ("\t\tResponse:", setup_resp.status_code, setup_resp.json())
-            print("== Creating default databases ===")
-
-            setup_resp=requests.put("http://127.0.0.1:5984/_users",  auth=creds, headers=headers)
-            print ("\tRequest: PUT http://127.0.0.1:5984/_users")
-            print ("\t\tResponse:", setup_resp.status_code, setup_resp.json())
-
-            setup_resp=requests.put("http://127.0.0.1:5984/_replicator",  auth=creds, headers=headers)
-            print ("\tRequest: PUT http://127.0.0.1:5984/_replicator")
-            print ("\t\tResponse:", setup_resp.status_code, setup_resp.json())
-
-            setup_resp=requests.put("http://127.0.0.1:5984/_global_changes",  auth=creds, headers=headers)
-            print ("\tRequest: PUT http://127.0.0.1:5984/_global_changes")
+            setup_resp=requests.get("http://127.0.0.1:5984/_cluster_setup",  auth=creds)
+            print ('\tRequest: GET http://127.0.0.1:5984/_cluster_setup')
             print ("\t\tResponse:", setup_resp.status_code, setup_resp.json())
 
             print("Time to relax!")
@@ -199,7 +200,6 @@ if __name__ == '__main__':
     connect_the_dots(peer_names)
     print('Cluster membership populated!')
     if (os.getenv("COUCHDB_USER") and os.getenv("COUCHDB_PASSWORD")):
-        enable_cluster(len(peer_names))
         finish_cluster(peer_names)
     else:
         print ('Skipping cluster setup. Username and/or password not provided')

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -106,6 +106,8 @@ def finish_cluster(names):
             # The node in <name> is primed
             # http://docs.couchdb.org/en/stable/cluster/setup.html
 
+            headers = {'Content-type': 'application/json'}
+
             # action: enable_cluster
             payload = {}
             payload['action'] = 'enable_cluster'
@@ -117,7 +119,9 @@ def finish_cluster(names):
             payload['remote_node'] = name
             payload['remote_current_user'] = creds[0]
             payload['remote_current_password'] = creds[1]
-            setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json.dumps(payload),  auth=creds)
+            setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json.dumps(payload),  auth=creds, headers=headers)
+            payload['password'] = "**masked**"
+            payload['remote_current_password'] = "**masked**"
             print ("POST to http://127.0.0.1:5984/_cluster_setup returned",setup_resp.status_code,"payload=",json.dumps(payload))
 
             # action: add_node
@@ -127,7 +131,8 @@ def finish_cluster(names):
             payload['password'] = creds[1]
             payload['port'] = 5984
             payload['host'] = name
-            setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json.dumps(payload),  auth=creds)
+            setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json.dumps(payload),  auth=creds, headers=headers)
+            payload['password'] = "**masked**"
             print ("POST to http://127.0.0.1:5984/_cluster_setup returned",setup_resp.status_code,"payload=",json.dumps(payload))
 
             print('CouchDB cluster peer {} added to "setup coordination node"'.format(name))
@@ -145,14 +150,17 @@ def finish_cluster(names):
 def enable_cluster(nr_of_peers):
     creds = (os.getenv("COUCHDB_USER"), os.getenv("COUCHDB_PASSWORD"))   
     if creds[0] and creds[1]:
+        headers = {'Content-type': 'application/json'}
+
         # http://docs.couchdb.org/en/stable/cluster/setup.html
         payload = {}
         payload['action'] = 'enable_cluster'
         payload['bind_address'] = '0.0.0.0'
         payload['username'] = creds[0]
         payload['password'] = creds[1]
-        payload['node_count'] = nr_of_peers
-        setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json.dumps(payload),  auth=creds)
+        payload['node_count'] = '{0}'.format(nr_of_peers)
+        setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json.dumps(payload),  auth=creds, headers=headers)
+        payload['password'] = "**masked**"
         print ("POST to http://127.0.0.1:5984/_cluster_setup returned",setup_resp.status_code,"payload=",json.dumps(payload))
 
 def sleep_forever():

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -58,7 +58,7 @@ def connect_the_dots(names):
 
     ordinal_of_this_pod = int(os.getenv("HOSTNAME").split("-")[-1])
     expected_ordinals = set(range(0, ordinal_of_this_pod))
-    found_ordinals = set()
+    found_ordinals = set([])
     for name in names:
         # Get the podname, get the stuff after last - and convert to int
         found_ordinals.add(int(name.split(".",1)[0].split("-")[-1]));

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -76,7 +76,7 @@ def finish_cluster(names):
         # primed with _nodes data before /_cluster_setup
         creds = (os.getenv("COUCHDB_USER"), os.getenv("COUCHDB_PASSWORD"))
         # Use the _members of "this" pod's CouchDB as reference
-        local_membership_uri = "http://127.0.0.1:5986/_membership"
+        local_membership_uri = "http://127.0.0.1:5984/_membership"
         print ("Fetching node mebership from this pod: {0}".format(local_membership_uri),flush=True)
         if creds[0] and creds[1]:
             local_resp = requests.get(local_membership_uri,  auth=creds)

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -67,7 +67,7 @@ def finish_cluster(names):
     # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-identity
     # we can make sure that this code is only bing run
     # on the "first" pod using this hack:
-    if True or (os.getenv("HOSTNAME").endswith("_0")):
+    if (os.getenv("HOSTNAME").endswith("_0")):
         # Make sure that ALL CouchDB cluster peers have been
         # primed with _nodes data before /_cluster_setup
         creds = (os.getenv("COUCHDB_USER"), os.getenv("COUCHDB_PASSWORD"))
@@ -77,32 +77,30 @@ def finish_cluster(names):
         else:
             local_resp = requests.get("http://{0}127.0.0.1:5984/_members")
         for name in names:
-            print("Probing. Checking {0}".format(name))
+            print("Probing node {0} for _members".format(name))
             if creds[0] and creds[1]:
                 remote_resp = requests.get("http://{0}:5984/_members".format(name),  auth=creds)
             else:
                 remote_resp = requests.get("http://{0}:5984/_members".format(name))
             while (remote_resp.status_code == 404) or (ordered(local_resp.json()) != ordered(remote_resp.json())):
-                print('Waiting for node {0} to be ready'.format(name))
+                print('Waiting for node {0} to have all node members populated'.format(name))
                 time.sleep(5)
                 if creds[0] and creds[1]:
                     remote_resp = requests.get("http://{0}:5984/_members".format(name),  auth=creds)
                 else:
                     remote_resp = requests.get("http://{0}:5984/_members".format(name))
-            print("CouchDB cluster member {} ready to form a cluster".format(name))
+            print("CouchDB cluster peer {} ready to form a cluster".format(name))
         # At this point ALL peers have _nodes populated. Finish the cluster setup!
         if creds[0] and creds[1]:
             setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={"action": "finish_cluster"},  auth=creds)
         else:
             setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={"action": "finish_cluster"})
         if (setup_resp.status_code == requests.codes.ok):
-            print("CouchDB cluster done. Time to relax!")
+            print("CouchDB cluster setup done. Time to relax!")
         else:
             print('Ouch! Failed the final step: http://127.0.0.1:5984/_cluster_setup returned {0}'.format(setup_resp.status_code))
     else:
         print("This pod is intentionally skipping the call to http://127.0.0.1:5984/_cluster_setup")
-
-
 
 
 def sleep_forever():

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -67,7 +67,7 @@ def finish_cluster(names):
     # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-identity
     # we can make sure that this code is only bing run
     # on the "first" pod using this hack:
-    if (os.getenv("HOSTNAME").endswith("_0")):
+    if True or (os.getenv("HOSTNAME").endswith("_0")):
         # Make sure that ALL CouchDB cluster peers have been
         # primed with _nodes data before /_cluster_setup
         creds = (os.getenv("COUCHDB_USER"), os.getenv("COUCHDB_PASSWORD"))
@@ -95,12 +95,12 @@ def finish_cluster(names):
             setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={"action": "finish_cluster"},  auth=creds)
         else:
             setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={"action": "finish_cluster"})
-        if (setup_resp.status_code == 200):
+        if (setup_resp.status_code == requests.codes.ok):
             print("CouchDB cluster done. Time to relax!")
         else:
-            print('Ouch! Failed with final step. http://127.0.0.1:5984/_cluster_setup returned {0}'.format(setup_resp.status_code))
+            print('Ouch! Failed the final step: http://127.0.0.1:5984/_cluster_setup returned {0}'.format(setup_resp.status_code))
     else:
-        print("This pod is not used to call /_setup_cluster")
+        print("This pod is intentionally skipping the call to http://127.0.0.1:5984/_cluster_setup")
 
 
 
@@ -112,6 +112,6 @@ def sleep_forever():
 if __name__ == '__main__':
     peer_names = discover_peers(construct_service_record())
     connect_the_dots(peer_names)
-    finish_cluster(peer_names)
     print('Cluster membership populated!')
+    finish_cluster(peer_names)
     sleep_forever()

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -45,7 +45,7 @@ def connect_the_dots(names):
         else:
             resp = requests.put(uri, data=json.dumps(doc))
         while resp.status_code != 201:
-            print('Waiting for _nodes DB to be created ...', flush=True)
+            print('Waiting for _nodes DB to be created.',uri,'returned', resp.status_code, flush=True)
             time.sleep(5)
             if creds[0] and creds[1]:
                 resp = requests.put(uri, data=json.dumps(doc), auth=creds)
@@ -119,7 +119,7 @@ def sleep_forever():
 
 if __name__ == '__main__':
     peer_names = discover_peers(construct_service_record())
-    print('Got the following peers fqdm from DNS lookup:',peer_names,flush=True)
+    print("Got the following peers' fqdm from DNS lookup:",peer_names,flush=True)
     connect_the_dots(peer_names)
     print('Cluster membership populated!')
     finish_cluster(peer_names)

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -149,6 +149,12 @@ def diff(first, second):
         second = set(second)
         return [item for item in first if item not in second]
 
+
+@backoff.on_exception(
+    backoff.expo,
+    requests.exceptions.ConnectionError,
+    max_tries=10
+)
 # Check if the _membership API on all (known) CouchDB nodes have the same values.
 # Returns true if sam. False in any other situation.
 def are_nodes_in_sync(names):
@@ -197,7 +203,7 @@ if __name__ == '__main__':
     connect_the_dots(peer_names)
     print("Got the following peers' fqdm from DNS lookup:",peer_names,flush=True)
     # loop until all CouchDB nodes discovered
-    while not are_nodes_in_sync(names):
+    while not are_nodes_in_sync(peer_names):
         time.sleep(5)
         peer_names = discover_peers(construct_service_record())
         connect_the_dots(peer_names)

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -146,9 +146,14 @@ def enable_cluster(nr_of_peers):
     creds = (os.getenv("COUCHDB_USER"), os.getenv("COUCHDB_PASSWORD"))   
     if creds[0] and creds[1]:
         # http://docs.couchdb.org/en/stable/cluster/setup.html
-        payload = '"action": "enable_cluster", "bind_address":"0.0.0.0", "{0}": "admin", "{1}":"password", "node_count":"{2}"'.format(creds[0],creds[1],nr_of_peers)
-        setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={payload},  auth=creds)
-        print ("POST to http://127.0.0.1:5984/_cluster_setup returned",setup_resp.status_code,"payload=",payload)
+        payload = {}
+        payload['action'] = 'enable_cluster'
+        payload['bind_address'] = '0.0.0.0'
+        payload['username'] = creds[0]
+        payload['password'] = creds[1]
+        payload['node_count'] = len(names)
+        setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json.dumps(payload),  auth=creds)
+        print ("POST to http://127.0.0.1:5984/_cluster_setup returned",setup_resp.status_code,"payload=",json.dumps(payload))
 
 def sleep_forever():
     while True:

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -119,6 +119,7 @@ def sleep_forever():
 
 if __name__ == '__main__':
     peer_names = discover_peers(construct_service_record())
+    print('Got the following peers fqdm from DNS lookup:',peer_names,flush=True)
     connect_the_dots(peer_names)
     print('Cluster membership populated!')
     finish_cluster(peer_names)

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -58,7 +58,7 @@ def connect_the_dots(names):
 
     ordinal_of_this_pod = int(os.getenv("HOSTNAME").split("-")[-1])
     expected_ordinals = set(range(0, ordinal_of_this_pod))
-    found_ordinals = Set()
+    found_ordinals = set()
     for name in names:
         # Get the podname, get the stuff after last - and convert to int
         found_ordinals.add(int(name.split(".",1)[0].split("-")[-1]));

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -132,8 +132,9 @@ def enable_cluster(nr_of_peers):
     creds = (os.getenv("COUCHDB_USER"), os.getenv("COUCHDB_PASSWORD"))   
     if creds[0] and creds[1]:
         # http://docs.couchdb.org/en/stable/cluster/setup.html
-        payload = '"action": "enable_cluster", "bind_address":"0.0.0.0", "{0}}": "admin", "{1}}":"password", "node_count":"{2}"'.format(creds[0],creds[1],nr_of_peers)
+        payload = '"action": "enable_cluster", "bind_address":"0.0.0.0", "{0}": "admin", "{1}":"password", "node_count":"{2}"'.format(creds[0],creds[1],nr_of_peers)
         setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={payload},  auth=creds)
+        print ("POST to http://127.0.0.1:5984/_cluster_setup returned",setup_resp.status_code,"payload=",payload)
 
 def sleep_forever():
     while True:

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -151,7 +151,7 @@ def enable_cluster(nr_of_peers):
         payload['bind_address'] = '0.0.0.0'
         payload['username'] = creds[0]
         payload['password'] = creds[1]
-        payload['node_count'] = len(names)
+        payload['node_count'] = nr_of_peers
         setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json.dumps(payload),  auth=creds)
         print ("POST to http://127.0.0.1:5984/_cluster_setup returned",setup_resp.status_code,"payload=",json.dumps(payload))
 

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -44,14 +44,15 @@ def connect_the_dots(names):
             resp = requests.put(uri, data=json.dumps(doc), auth=creds)
         else:
             resp = requests.put(uri, data=json.dumps(doc))
-        while resp.status_code != 201:
-            print('Waiting for _nodes DB to be created.',uri,'returned', resp.status_code, flush=True)
+        while resp.status_code != 201 and resp.status_code != 409:
+            print('Waiting for _nodes DB to be created.',uri,'returned', resp.status_code, resp.json(), flush=True)
             time.sleep(5)
             if creds[0] and creds[1]:
                 resp = requests.put(uri, data=json.dumps(doc), auth=creds)
             else:
                 resp = requests.put(uri, data=json.dumps(doc))
-        print('Adding CouchDB cluster node', name, "to this pod's CouchDB. Response code:", resp.status_code ,flush=True)
+        if resp.status_code == 201:
+            print('Adding CouchDB cluster node', name, "to this pod's CouchDB. Response code:", resp.status_code ,flush=True)
 
 # Run action:enable_cluster on every CouchDB cluster node
 def enable_cluster(nr_of_peers):

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -114,7 +114,8 @@ def are_nodes_in_sync(names):
         local_resp = requests.get(local_membership_uri)
 
     # If any difference is found - set to true
-    is_different = False;
+    is_different = False
+
     # Step through every peer. Ensure they are "ready" before progressing.
     for name in names:
         print("Probing {0} for cluster membership".format(name))
@@ -123,6 +124,11 @@ def are_nodes_in_sync(names):
             remote_resp = requests.get(remote_membership_uri,  auth=creds)
         else:
             remote_resp = requests.get(remote_membership_uri)
+
+        if len(names) < 2:
+            # Minimum 2 nodes to form cluster!
+            is_different = True   
+
         # Compare local and remote _mebership data. Make sure the set
         # of nodes match. This will ensure that the remote nodes
         # are fully primed with nodes data before progressing with
@@ -142,6 +148,10 @@ def are_nodes_in_sync(names):
                     print ("Cluster members in {0} not yet present in {1}: {2}".format(name.split(".",1)[0], os.getenv("HOSTNAME"), records_in_remote_but_not_in_local))
         else:
             is_different = True
+ 
+        if (remote_resp.status_code == 200) and (local_resp.status_code == 200):
+            print("local: ",local_resp.json().cluster_nodes)
+            print("remote: ",remote_resp.json().cluster_nodes)
         print('returnerar', not is_different)
     return not is_different
 

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -98,7 +98,7 @@ def finish_cluster(names):
         print ("=== Adding nodes to CouchDB cluster via the “setup coordination node” ===")
         for name in names:
             # Exclude "this" pod
-            if (name.split(".",1)[0]) != os.getenv("HOSTNAME")):
+            if (name.split(".",1)[0] != os.getenv("HOSTNAME")):
                 # action: enable_cluster
                 payload = {}
                 payload['action'] = 'enable_cluster'

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -63,8 +63,8 @@ def connect_the_dots(names):
         # Get the podname, get the stuff after last - and convert to int
         found_ordinals.add(int(name.split(".",1)[0].split("-")[-1]));
 
-    print("expected_ordinals",expected_ordinals)
-    print("found ordnials",found_ordinals)
+    # print("expected_ordinals",expected_ordinals)
+    # print("found ordnials",found_ordinals)
 
     # Are there expected ordinals that are not part of the found ordinals?
     if( expected_ordinals - found_ordinals):
@@ -107,7 +107,7 @@ def finish_cluster(names):
     # on the "first" pod only with this hack:
     if (os.getenv("HOSTNAME").endswith("-0")):
         creds = (os.getenv("COUCHDB_USER"), os.getenv("COUCHDB_PASSWORD"))
-        print("== Get the cluster up and running ===")
+        print("Get the cluster up and running")
         setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={"action": "finish_cluster"},  auth=creds)
         print ('\t| Request: POST http://127.0.0.1:5984/_cluster_setup , payload {"action": "finish_cluster"}')
         print ("\t|\tResponse:", setup_resp.status_code, setup_resp.json())
@@ -120,7 +120,7 @@ def finish_cluster(names):
         else:
             print('Ouch! Failed the final step finalizing the cluster.')
     else:
-        print('This pod is intentionally skipping the POST to http://127.0.0.1:5984/_cluster_setup {"action": "finish_cluster"}')
+        print('Intentionally skipping the POST to http://127.0.0.1:5984/_cluster_setup {"action": "finish_cluster"}')
 
 
 @backoff.on_exception(
@@ -202,5 +202,5 @@ if __name__ == '__main__':
     if (os.getenv("COUCHDB_USER") and os.getenv("COUCHDB_PASSWORD")):
         finish_cluster(peer_names)
     else:
-        print ('Skipping cluster final setup. Username and/or password not provided')
+        print ('Skipping final cluster setup. Username and/or password not provided')
     sleep_forever()

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -47,7 +47,10 @@ def connect_the_dots(names):
         while resp.status_code == 404:
             print('Waiting for _nodes DB to be created ...', flush=True)
             time.sleep(5)
-            resp = requests.put(uri, data=json.dumps(doc))
+            if creds[0] and creds[1]:
+                resp = requests.put(uri, data=json.dumps(doc), auth=creds)
+            else:
+                resp = requests.put(uri, data=json.dumps(doc))
         print('Adding cluster member', name, resp.status_code, flush=True)
 
 # Compare (json) objects - order does not matter. Credits to:

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -72,10 +72,12 @@ def finish_cluster(names):
         # primed with _nodes data before /_cluster_setup
         creds = (os.getenv("COUCHDB_USER"), os.getenv("COUCHDB_PASSWORD"))
         # Use the _members of "this" pod's CouchDB as reference
+        local_members_uri = "http://127.0.0.1:5984/_members"
+        print ("Fetching node mebership from this pod: {0}".format(local_members_uri))
         if creds[0] and creds[1]:
-            local_resp = requests.get("http://{0}127.0.0.1:5984/_members",  auth=creds)
+            local_resp = requests.get(local_members_uri,  auth=creds)
         else:
-            local_resp = requests.get("http://{0}127.0.0.1:5984/_members")
+            local_resp = requests.get(local_members_uri)
         for name in names:
             print("Probing node {0} for _members".format(name))
             if creds[0] and creds[1]:

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -67,7 +67,7 @@ def finish_cluster(names):
     # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-identity
     # we can make sure that this code is only bing run
     # on the "first" pod using this hack:
-    if (os.getenv("HOSTNAME").endswith("_1")):
+    if (os.getenv("HOSTNAME").endswith("_0")):
         # Make sure that ALL CouchDB cluster peers have been
         # primed with _nodes data before /_cluster_setup
         creds = (os.getenv("COUCHDB_USER"), os.getenv("COUCHDB_PASSWORD"))
@@ -77,7 +77,7 @@ def finish_cluster(names):
         else:
             local_resp = requests.get("http://{0}127.0.0.1:5984/_members")
         for name in names:
-            print('Probing ', name)
+            print("Probing. Checking {0}".format(name))
             if creds[0] and creds[1]:
                 remote_resp = requests.get("http://{0}:5984/_members".format(name),  auth=creds)
             else:
@@ -89,18 +89,19 @@ def finish_cluster(names):
                     remote_resp = requests.get("http://{0}:5984/_members".format(name),  auth=creds)
                 else:
                     remote_resp = requests.get("http://{0}:5984/_members".format(name))
-            print('CouchDB cluster member {} ready to form a cluster'.format(name))
+            print("CouchDB cluster member {} ready to form a cluster".format(name))
         # At this point ALL peers have _nodes populated. Finish the cluster setup!
         payload = {}
         if creds[0] and creds[1]:
-            setup_resp=requests.post('http://127.0.0.1:5984/_cluster_setup', json={"action": "finish_cluster"},  auth=creds)
+            setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={"action": "finish_cluster"},  auth=creds)
         else:
-            setup_resp=requests.post('http://127.0.0.1:5984/_cluster_setup', json={"action": "finish_cluster"},  auth=creds)
-        if (setup_resp.status_code == 200)
-            print('CouchDB cluster done. Time to relax!')
+            setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={"action": "finish_cluster"})
+        if setup_resp.status_code == 200:
+            print("CouchDB cluster done. Time to relax!")
         else:
             print('Ouch! Failed with final step. http://127.0.0.1:5984/_cluster_setup returned {0}'.format(setup_resp.status_code))
-            
+    else:
+        print("This pod is not used to call /_setup_cluster")
 
 
 

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -160,7 +160,7 @@ def finish_cluster(names):
             print('CouchDB cluster peer {} added to "setup coordination node"'.format(name))
         # At this point ALL peers have _nodes populated. Finish the cluster setup!
 
-        print("== Creating default databases ===")
+"""         print("== Creating default databases ===")
         setup_resp=requests.put("http://127.0.0.1:5984/_users",  auth=creds)
         print ("\tRequest: PUT http://127.0.0.1:5984/_users")
         print ("\t\tResponse:", setup_resp.status_code, setup_resp.json())
@@ -171,7 +171,7 @@ def finish_cluster(names):
 
         setup_resp=requests.put("http://127.0.0.1:5984/_global_changes",  auth=creds)
         print ("\tRequest: PUT http://127.0.0.1:5984/_global_changes")
-        print ("\t\tResponse:", setup_resp.status_code, setup_resp.json())
+        print ("\t\tResponse:", setup_resp.status_code, setup_resp.json()) """
 
         setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={"action": "finish_cluster"},  auth=creds)
         if (setup_resp.status_code == 201):

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -107,14 +107,28 @@ def finish_cluster(names):
             # http://docs.couchdb.org/en/stable/cluster/setup.html
 
             # action: enable_cluster
-            payload = '"action": "enable_cluster", "bind_address":"0.0.0.0", "username":"{0}", "password":"{1}", "port": 5984, "node_count":"{2}"  "remote_node": "{3}", "remote_current_user": "{0}", "remote_current_password": "{1}"'.format(creds[0],creds[1],nr_of_peers,name)
-            setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={payload},  auth=creds)
-            print ("POST to http://127.0.0.1:5984/_cluster_setup returned",setup_resp.status_code,"payload=",payload)
+            payload = {}
+            payload['action'] = 'enable_cluster'
+            payload['bind_address'] = '0.0.0.0'
+            payload['username'] = creds[0]
+            payload['password'] = creds[1]
+            payload['port'] = 5984
+            payload['node_count'] = len(names)
+            payload['remote_node'] = name
+            payload['remote_current_user'] = creds[0]
+            payload['remote_current_password'] = creds[1]
+            setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json.dumps(payload),  auth=creds)
+            print ("POST to http://127.0.0.1:5984/_cluster_setup returned",setup_resp.status_code,"payload=",json.dumps(payload))
 
             # action: add_node
-            payload = '"action": "add_node", "host":"{0}", "port": 5984, "username": "{1}", "password":"{2}"'.format(name, creds[0],creds[1])
-            setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json={payload},  auth=creds)
-            print ("POST to http://127.0.0.1:5984/_cluster_setup returned",setup_resp.status_code,"payload=",payload)
+            payload = {}
+            payload['action'] = 'add_node'
+            payload['username'] = creds[0]
+            payload['password'] = creds[1]
+            payload['port'] = 5984
+            payload['host'] = name
+            setup_resp=requests.post("http://127.0.0.1:5984/_cluster_setup", json.dumps(payload),  auth=creds)
+            print ("POST to http://127.0.0.1:5984/_cluster_setup returned",setup_resp.status_code,"payload=",json.dumps(payload))
 
             print('CouchDB cluster peer {} added to "setup coordination node"'.format(name))
         # At this point ALL peers have _nodes populated. Finish the cluster setup!

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -50,11 +50,68 @@ def connect_the_dots(names):
             resp = requests.put(uri, data=json.dumps(doc))
         print('Adding cluster member', name, resp.status_code)
 
+# Compare (json) objects - order does not matter. Credits to:
+# https://stackoverflow.com/a/25851972
+def ordered(obj):
+    if isinstance(obj, dict):
+        return sorted((k, ordered(v)) for k, v in obj.items())
+    if isinstance(obj, list):
+        return sorted(ordered(x) for x in obj)
+    else:
+        return obj
+
+def finish_cluster(names):
+    # The HTTP POST to /_cluster_setup should be done to
+    # one (and only one) of the CouchDB cluster nodes.
+    # Given that K8S has a standardized naming for the pods:
+    # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-identity
+    # we can make sure that this code is only bing run
+    # on the "first" pod using this hack:
+    if (os.getenv("HOSTNAME").endswith("_1")):
+        # Make sure that ALL CouchDB cluster peers have been
+        # primed with _nodes data before /_cluster_setup
+        creds = (os.getenv("COUCHDB_USER"), os.getenv("COUCHDB_PASSWORD"))
+        # Use the _members of "this" pod's CouchDB as reference
+        if creds[0] and creds[1]:
+            local_resp = requests.get("http://{0}127.0.0.1:5984/_members",  auth=creds)
+        else:
+            local_resp = requests.get("http://{0}127.0.0.1:5984/_members")
+        for name in names:
+            print('Probing ', name)
+            if creds[0] and creds[1]:
+                remote_resp = requests.get("http://{0}:5984/_members".format(name),  auth=creds)
+            else:
+                remote_resp = requests.get("http://{0}:5984/_members".format(name))
+            while (remote_resp.status_code == 404) or (ordered(local_resp.json()) != ordered(remote_resp.json())):
+                print('Waiting for node {0} to be ready'.format(name))
+                time.sleep(5)
+                if creds[0] and creds[1]:
+                    remote_resp = requests.get("http://{0}:5984/_members".format(name),  auth=creds)
+                else:
+                    remote_resp = requests.get("http://{0}:5984/_members".format(name))
+            print('CouchDB cluster member {} ready to form a cluster'.format(name))
+        # At this point ALL peers have _nodes populated. Finish the cluster setup!
+        payload = {}
+        if creds[0] and creds[1]:
+            setup_resp=requests.post('http://127.0.0.1:5984/_cluster_setup', json={"action": "finish_cluster"},  auth=creds)
+        else:
+            setup_resp=requests.post('http://127.0.0.1:5984/_cluster_setup', json={"action": "finish_cluster"},  auth=creds)
+        if (setup_resp.status_code == 200)
+            print('CouchDB cluster done. Time to relax!')
+        else:
+            print('Ouch! Failed with final step. http://127.0.0.1:5984/_cluster_setup returned {0}'.format(setup_resp.status_code))
+            
+
+
+
+
 def sleep_forever():
     while True:
         time.sleep(5)
 
 if __name__ == '__main__':
-    connect_the_dots(discover_peers(construct_service_record()))
+    peer_names = discover_peers(construct_service_record())
+    connect_the_dots(peer_names)
+    finish_cluster(peer_names)
     print('Cluster membership populated!')
     sleep_forever()

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -32,7 +32,7 @@ def discover_peers(service_record):
     # name to form the hostname used for the Erlang node. This feels hacky
     # but not sure of a more official answer
     result = [rdata.target.to_text()[:-1] for rdata in answers]
-    print("\t| Got the following peers' fqdm from DNS lookup:",result,flush=True)
+    print("\t| Got the following peers' fqdn from DNS lookup:",result,flush=True)
     return result
 
 def backoff_hdlr(details):

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -140,8 +140,8 @@ def are_nodes_in_sync(names):
             if ordered(local_resp.json()) != ordered(remote_resp.json()):
                 is_different = True
                 print ("Fetching CouchDB node mebership from this pod: {0}".format(local_membership_uri),flush=True)
-                records_in_local_but_not_in_remote = set(local_resp.json().cluster_nodes) - set(remote_resp.json().cluster_nodes)
-                records_in_remote_but_not_in_local = set(remote_resp.json().cluster_nodes) - set(local_resp.json().cluster_nodes)
+                records_in_local_but_not_in_remote = set(local_resp.json()['cluster_nodes']) - set(remote_resp.json()['cluster_nodes'])
+                records_in_remote_but_not_in_local = set(remote_resp.json()['cluster_nodes']) - set(local_resp.json()['cluster_nodes'])
                 if records_in_local_but_not_in_remote:
                     print ("Cluster members in {0} not yet present in {1}: {2}".format(os.getenv("HOSTNAME"), name.split(".",1)[0], records_in_local_but_not_in_remote))
                 if records_in_remote_but_not_in_local:
@@ -150,8 +150,8 @@ def are_nodes_in_sync(names):
             is_different = True
  
         if (remote_resp.status_code == 200) and (local_resp.status_code == 200):
-            print("local: ",local_resp.json().cluster_nodes)
-            print("remote: ",remote_resp.json().cluster_nodes)
+            print("local: ",local_resp.json()['cluster_nodes'])
+            print("remote: ",remote_resp.json()['cluster_nodes'])
         print('returnerar', not is_different)
     return not is_different
 

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -164,6 +164,7 @@ def are_nodes_in_sync(names):
     # "source"
     local_membership_uri = "http://127.0.0.1:5984/_membership"
     print ("Fetching CouchDB node mebership from this pod: {0}".format(local_membership_uri),flush=True)
+    creds = (os.getenv("COUCHDB_USER"), os.getenv("COUCHDB_PASSWORD"))   
     if creds[0] and creds[1]:
         local_resp = requests.get(local_membership_uri,  auth=creds)
     else:
@@ -182,6 +183,9 @@ def are_nodes_in_sync(names):
         # are fully primed with nodes data before progressing with
         # _cluster_setup
         if (remote_resp.status_code == 200) and (local_resp.status_code == 200):
+            if len(local_resp.json()) < 2:
+                # Minimum 2 nodes to form cluster!
+                is_different = True
             if ordered(local_resp.json()) != ordered(remote_resp.json()):
                 is_different = True
                 print ("Fetching CouchDB node mebership from this pod: {0}".format(local_membership_uri),flush=True)

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -66,28 +66,21 @@ def connect_the_dots(names):
     print("expected_ordinals",expected_ordinals)
     print("found ordnials",found_ordinals)
 
-    # Are all expected_ordinals are part of found_ordinals?
+    # Are there expected ordinals that are not part of the found ordinals?
     if( expected_ordinals - found_ordinals):
-        print ('Expected to get at least pod(s)', expected_ordinals - found_ordinals, 'among the DNS records. Will retry.')
+        print ('Expected to get at least the following pod ordinal(s)', expected_ordinals - found_ordinals, 'among the DNS records. Will retry.')
     else:
         creds = (os.getenv("COUCHDB_USER"), os.getenv("COUCHDB_PASSWORD"))
         for name in names:
             uri = "http://127.0.0.1:5986/_nodes/couchdb@{0}".format(name)
             doc = {}
-
+            print('Adding CouchDB cluster node', name, "to this pod's CouchDB.")
+            print ('\tRequest: GET',uri)
             if creds[0] and creds[1]:
                 resp = requests.put(uri, data=json.dumps(doc), auth=creds)
             else:
                 resp = requests.put(uri, data=json.dumps(doc))
-            while resp.status_code != 201 and resp.status_code != 409:
-                print('Waiting for _nodes DB to be created.',uri,'returned', resp.status_code, resp.json(), flush=True)
-                time.sleep(5)
-                if creds[0] and creds[1]:
-                    resp = requests.put(uri, data=json.dumps(doc), auth=creds)
-                else:
-                    resp = requests.put(uri, data=json.dumps(doc))
-            if resp.status_code == 201:
-                print('Adding CouchDB cluster node', name, "to this pod's CouchDB. Response code:", resp.status_code ,flush=True)
+            print ("\tResponse:", setup_resp.status_code, setup_resp.json(),flush=True)
 
 # Compare (json) objects - order does not matter. Credits to:
 # https://stackoverflow.com/a/25851972

--- a/mem3_helper.py
+++ b/mem3_helper.py
@@ -81,7 +81,7 @@ def connect_the_dots(names):
                     resp = requests.put(uri, data=json.dumps(doc), auth=creds)
                 else:
                     resp = requests.put(uri, data=json.dumps(doc))
-                print ("\t| Response:", setup_resp.status_code, setup_resp.json(),flush=True)
+                print ("\t| Response:", resp.status_code, resp.json(),flush=True)
             except requests.exceptions.ConnectionError:
                 print ('\t| Connection failure. CouchDB not responding. Will retry.')
 


### PR DESCRIPTION
This PR will (in listed order):
1. Ensure that all CouchDB containers get all peers registered in _node db
2. Do the POST http://127.0.0.1:5984/_cluster_setup , payload {"action": "finish_cluster"} on pod with ordinal nr 0 (if username and password provided)

The intention is that the cluster will succeed with setup even if some of the CouchDB nodes are restarted during cluster formation (e.g. du to Liveness or Readiness settings).

It's my first hands-on with Python so... pick, chose and modify as you see fit if you chose to accept this PR.

Below are example logs from formation of a 3-node cluster.
```
kubectl logs -f my-release-couchdb-2 -c couchdb-statefulset-assembler       
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
	| Got the following peers' fqdm from DNS lookup: ['my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local']
Adding CouchDB cluster node my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local
	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
Adding CouchDB cluster node my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local
	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
Adding CouchDB cluster node my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local
	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
Probing my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local for cluster membership
	| In sync!
Probing my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local for cluster membership
	| In sync!
Probing my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local for cluster membership
	| In sync!
Cluster membership populated!
Intentionally skipping the POST to http://127.0.0.1:5984/_cluster_setup {"action": "finish_cluster"}
```

```
kubectl logs -f my-release-couchdb-1 -c couchdb-statefulset-assembler
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
	| Got the following peers' fqdm from DNS lookup: ['my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local']
Adding CouchDB cluster node my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local
	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
Adding CouchDB cluster node my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local
	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
Adding CouchDB cluster node my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local
	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
Probing my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local for cluster membership
	| In sync!
Probing my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local for cluster membership
	| In sync!
Probing my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local for cluster membership
	| In sync!
Cluster membership populated!
Intentionally skipping the POST to http://127.0.0.1:5984/_cluster_setup {"action": "finish_cluster"}
```

```
kubectl logs -f my-release-couchdb-0 -c couchdb-statefulset-assembler
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
	| Got the following peers' fqdm from DNS lookup: ['my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local']
Adding CouchDB cluster node my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local
	| Response: 201 {'ok': True, 'id': 'couchdb@my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local', 'rev': '1-967a00dff5e02add41819138abb3284d'}
Adding CouchDB cluster node my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local
	| Response: 201 {'ok': True, 'id': 'couchdb@my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local', 'rev': '1-967a00dff5e02add41819138abb3284d'}
Adding CouchDB cluster node my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local
	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
Probing my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local for cluster membership
	| Cluster members in my-release-couchdb-0 not yet present in my-release-couchdb-2: {'couchdb@my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local', 'couchdb@my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local'}
Probing my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local for cluster membership
	| Cluster members in my-release-couchdb-0 not yet present in my-release-couchdb-1: {'couchdb@my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local', 'couchdb@my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local'}
Probing my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local for cluster membership
	| In sync!
Resolving SRV record _couchdb._tcp.my-release-couchdb.default.svc.cluster.local
	| Got the following peers' fqdm from DNS lookup: ['my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local', 'my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local']
Adding CouchDB cluster node my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local
	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
Adding CouchDB cluster node my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local
	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
Adding CouchDB cluster node my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local to this pod's CouchDB.
	| Request: PUT http://127.0.0.1:5986/_nodes/couchdb@my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local
	| Response: 409 {'error': 'conflict', 'reason': 'Document update conflict.'}
Probing my-release-couchdb-2.my-release-couchdb.default.svc.cluster.local for cluster membership
	| In sync!
Probing my-release-couchdb-1.my-release-couchdb.default.svc.cluster.local for cluster membership
	| In sync!
Probing my-release-couchdb-0.my-release-couchdb.default.svc.cluster.local for cluster membership
	| In sync!
Cluster membership populated!
Get the cluster up and running
	| Request: POST http://127.0.0.1:5984/_cluster_setup , payload {"action": "finish_cluster"}
	|	Response: 201 {'ok': True}
	| Sweet! Just a final check for the logs...
	| Request: GET http://127.0.0.1:5984/_cluster_setup
	|	Response: 200 {'state': 'cluster_finished'}
Time to relax!
```